### PR TITLE
make it compile in clang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@
 *.exe
 *.out
 *.app
+
+# test executables
+*.dSYM/
+TEST_*

--- a/src/tagger/Data.cc
+++ b/src/tagger/Data.cc
@@ -250,7 +250,7 @@ public:
 
   void set_label_candidates(const std::string &word_form, 
 			    bool use_lexicon,
-			    float mass, 
+			    float count,
 			    LabelVector &target) const
   {
     static_cast<void>(word_form);

--- a/src/tagger/ParamTable.cc
+++ b/src/tagger/ParamTable.cc
@@ -456,13 +456,13 @@ int main(void)
   pt.update_unstruct(pt.get_feat_template("FOO"), 0, 1);
   assert(pt.get_unstruct(pt.get_feat_template("FOO"), 0) == 2);
 
-  assert(pt.get_struct1(0) == 0);
-  pt.update_struct1(0, 1);
-  assert(pt.get_struct1(0) == 1);
+  assert(pt.get_struct1(0, false) == 0);
+  pt.update_struct1(0, 1, false);
+  assert(pt.get_struct1(0, false) == 1);
 
-  assert(pt.get_struct1(1) == 0);
-  pt.update_struct1(1, 2);
-  assert(pt.get_struct1(1) == 2);
+  assert(pt.get_struct1(1, false) == 0);
+  pt.update_struct1(1, 2, false);
+  assert(pt.get_struct1(1, false) == 2);
 
   assert(pt.get_struct2(0, 0, false) == 0);
   pt.update_struct2(0, 0, 1, false);

--- a/src/tagger/Sentence.cc
+++ b/src/tagger/Sentence.cc
@@ -194,7 +194,7 @@ public:
 
   void set_label_candidates(const std::string &word_form, 
 			    bool use_lexicon,
-			    unsigned int count, 
+			    float count,
 			    LabelVector &target) const
   {
     static_cast<void>(word_form);

--- a/src/tagger/Trellis.cc
+++ b/src/tagger/Trellis.cc
@@ -423,8 +423,8 @@ int main(void)
   pt.update_struct3(0,0,9,7.494);
   pt.update_struct2(0,9,5.891, false);
   pt.update_struct2(0,1,0.883, false);
-  pt.update_struct1(9,2.275);
-  pt.update_struct1(1,3.68);
+  pt.update_struct1(9,2.275, false);
+  pt.update_struct1(1,3.68, false);
 
   pt.update_struct3(1,1,1,5.206);
   pt.update_struct3(1,1,9,4.958);
@@ -475,15 +475,15 @@ int main(void)
 
 	      f += pt.get_struct3(0, 0, labels[i]);
 	      f += pt.get_struct2(0, labels[i], false);
-	      f += pt.get_struct1(labels[i]);
+	      f += pt.get_struct1(labels[i], false);
 
 	      f += pt.get_struct3(0, labels[i], labels[j]);
 	      f += pt.get_struct2(labels[i], labels[j], false);
-	      f += pt.get_struct1(labels[j]);
+	      f += pt.get_struct1(labels[j], false);
 
 	      f += pt.get_struct3(labels[i], labels[j], labels[k]);
 	      f += pt.get_struct2(labels[j], labels[k], false);
-	      f += pt.get_struct1(labels[k]);
+	      f += pt.get_struct1(labels[k], false);
 	      
 	      f += pt.get_struct3(labels[j], labels[k], 0);
 	      f += pt.get_struct3(labels[k], 0, 0);

--- a/src/tagger/Trellis.cc
+++ b/src/tagger/Trellis.cc
@@ -334,7 +334,7 @@ public:
 
   void set_label_candidates(const std::string &word_form, 
 			    bool use_lexicon,
-			    unsigned int count, 
+			    float count,
 			    LabelVector &target) const
   {
     static_cast<void>(word_form);

--- a/src/tagger/TrellisColumn.cc
+++ b/src/tagger/TrellisColumn.cc
@@ -487,12 +487,12 @@ int main(void)
   col2.set_ncol(&rbcol1);
   rbcol1.set_ncol(&rbcol2);
   
-  lbcol.set_word(boundary);
-  col0.set_word(dog);
-  col1.set_word(cat);
-  col2.set_word(horse);
-  rbcol1.set_word(boundary);
-  rbcol2.set_word(boundary);
+  lbcol.set_word(boundary, 0);
+  col0.set_word(dog, 0);
+  col1.set_word(cat, 0);
+  col2.set_word(horse, 0);
+  rbcol1.set_word(boundary, 0);
+  rbcol2.set_word(boundary, 0);
 
   ParamTable pt;
   
@@ -656,12 +656,12 @@ int main(void)
   foo_col4.set_ncol(&foo_col5);
   foo_col5.set_ncol(&foo_col6);
 
-  foo_col1.set_word(boundary);
-  foo_col2.set_word(foo);
-  foo_col3.set_word(foo);
-  foo_col4.set_word(foo);
-  foo_col5.set_word(boundary);
-  foo_col6.set_word(boundary);
+  foo_col1.set_word(boundary, 0);
+  foo_col2.set_word(foo, 0);
+  foo_col3.set_word(foo, 0);
+  foo_col4.set_word(foo, 0);
+  foo_col5.set_word(boundary, 0);
+  foo_col6.set_word(boundary, 0);
 
   foo_col6.compute_viterbi(foo_pt);
   assert(float_equals(foo_col6.get_viterbi(0,0), 1000 - 2));
@@ -679,12 +679,12 @@ int main(void)
   bar_col4.set_ncol(&bar_col5);
   bar_col5.set_ncol(&bar_col6);
 
-  bar_col1.set_word(boundary);
-  bar_col2.set_word(foo);
-  bar_col3.set_word(foo);
-  bar_col4.set_word(foo);
-  bar_col5.set_word(boundary);
-  bar_col6.set_word(boundary);
+  bar_col1.set_word(boundary, 0);
+  bar_col2.set_word(foo, 0);
+  bar_col3.set_word(foo, 0);
+  bar_col4.set_word(foo, 0);
+  bar_col5.set_word(boundary, 0);
+  bar_col6.set_word(boundary, 0);
 
   bar_col6.compute_viterbi(foo_pt);
   assert(float_equals(bar_col6.get_viterbi(0,0), 1000 - 2));
@@ -702,12 +702,12 @@ int main(void)
   baz_col4.set_ncol(&baz_col5);
   baz_col5.set_ncol(&baz_col6);
 
-  baz_col1.set_word(boundary);
-  baz_col2.set_word(foo);
-  baz_col3.set_word(foo);
-  baz_col4.set_word(foo);
-  baz_col5.set_word(boundary);
-  baz_col6.set_word(boundary);
+  baz_col1.set_word(boundary, 0);
+  baz_col2.set_word(foo, 0);
+  baz_col3.set_word(foo, 0);
+  baz_col4.set_word(foo, 0);
+  baz_col5.set_word(boundary, 0);
+  baz_col6.set_word(boundary, 0);
 
   baz_col6.compute_viterbi(foo_pt);
  

--- a/src/tagger/UnorderedMapSet.hh
+++ b/src/tagger/UnorderedMapSet.hh
@@ -1,17 +1,33 @@
 #ifndef HEADER_UnorderedMapSet_hh
 #define HEADER_UnorderedMapSet_hh
 
-#include <tr1/unordered_map>
-#include <tr1/unordered_set>
-
 // Ugly gum to make unordered_map and unordered_set work the same on
 // all platforms.
+
+#if __cplusplus >= 201103L
+
+#include <unordered_map>
+#include <unordered_set>
+
+namespace std
+{
+  using std::unordered_map;
+  using std::unordered_set;
+}
+
+#else
+
+#include <tr1/unordered_map>
+#include <tr1/unordered_set>
 
 namespace std
 {
   using std::tr1::unordered_map;
   using std::tr1::unordered_set;
 }
+
+#endif  // if __cplusplus >= 201103L
+
 
 template<class T, class U> bool operator!=(const std::unordered_map<T,U> &m1,
 					   const std::unordered_map<T,U> &m2);

--- a/src/tagger/Word.cc
+++ b/src/tagger/Word.cc
@@ -143,7 +143,7 @@ public:
 
   void set_label_candidates(const std::string &word_form, 
 			    bool use_lexicon,
-			    unsigned int count, 
+			    float count,
 			    LabelVector &target) const
   {
     static_cast<void>(word_form);

--- a/src/tagger/io.cc
+++ b/src/tagger/io.cc
@@ -598,8 +598,8 @@ int main(void)
   m3.clear();
   m3[0].first = 0;
   m3[0].second = 1;
-  m3[100].first = 5.1;
-  m3[100].second = 16;
+  m3[100].first = 5;
+  m3[100].second = 16.1;
   write_map<int, int, float>(map_out_8, m3);
   m_copy3.clear();
   std::istringstream map_in_8(map_out_8.str());


### PR DESCRIPTION
Hey @mpsilfve,

I'm not a C++ expert, but here are some changes to make tests compile on OS X. 
They were required to make `cd src/tagger; make tests` compile.
Some tests still don't compile for me, e.g. 

```
make TEST_Trellis
clang++ -Wall -Wextra -g -O3 -Wfatal-errors -Werror -std=c++0x   -c -o io.o io.cc
clang++ -Wall -Wextra -g -O3 -Wfatal-errors -Werror -std=c++0x   -c -o Word.o Word.cc
clang++ -Wall -Wextra -g -O3 -Wfatal-errors -Werror -std=c++0x   -c -o LemmaExtractor.o LemmaExtractor.cc
clang++ -Wall -Wextra -g -O3 -Wfatal-errors -Werror -std=c++0x   -c -o LabelExtractor.o LabelExtractor.cc
clang++ -Wall -Wextra -g -O3 -Wfatal-errors -Werror -std=c++0x   -c -o Sentence.o Sentence.cc
clang++ -Wall -Wextra -g -O3 -Wfatal-errors -Werror -std=c++0x   -c -o ParamTable.o ParamTable.cc
clang++ -Wall -Wextra -g -O3 -Wfatal-errors -Werror -std=c++0x   -c -o Data.o Data.cc
clang++ -Wall -Wextra -g -O3 -Wfatal-errors -Werror -std=c++0x   -c -o TrellisColumn.o TrellisColumn.cc
clang++ -Wall -Wextra -g -O3 -Wfatal-errors -Werror -std=c++0x   -c -o Trellis.o Trellis.cc
clang++ -Wall -Wextra -g -O3 -Wfatal-errors -Werror -std=c++0x   -c -o Trainer.o Trainer.cc
clang++ -Wall -Wextra -g -O3 -Wfatal-errors -Werror -std=c++0x   -c -o PerceptronTrainer.o PerceptronTrainer.cc
clang++ -Wall -Wextra -g -O3 -Wfatal-errors -Werror -std=c++0x   -c -o SGDTrainer.o SGDTrainer.cc
clang++ -Wall -Wextra -g -O3 -Wfatal-errors -Werror -std=c++0x   -c -o TrellisCell.o TrellisCell.cc
clang++ -Wall -Wextra -g -O3 -Wfatal-errors -Werror -std=c++0x   -c -o Tagger.o Tagger.cc
clang++ -Wall -Wextra -g -O3 -Wfatal-errors -Werror -std=c++0x   -c -o TaggerOptions.o TaggerOptions.cc
clang++ -Wall -Wextra -g -O3 -Wfatal-errors -Werror -std=c++0x   -c -o SuffixLabelMap.o SuffixLabelMap.cc
clang++ -Wall -Wextra -g -O3 -Wfatal-errors -Werror -std=c++0x -DTEST_Trellis_cc -o TEST_Trellis io.o Word.o LemmaExtractor.o LabelExtractor.o Sentence.o ParamTable.o Data.o TrellisColumn.o Trellis.o Trainer.o PerceptronTrainer.o SGDTrainer.o TrellisCell.o Tagger.o TaggerOptions.o SuffixLabelMap.o Trellis.cc
duplicate symbol __Z8float_eqff in:
    TaggerOptions.o
    /var/folders/_5/cbsg50991szfp1r9nwxpx8580000gn/T/Trellis-9878f7.o
ld: 1 duplicate symbol for architecture x86_64
clang: fatal error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [TEST_Trellis] Error 1
```

Some tests pass (TEST_Word, TEST_io, TEST_LabelExtractor, TEST_Sentence,  TEST_ParamTable, TEST_Data).

Some segfault:

```
> ./TEST_LemmaExtractor
Assertion failed: (lemma_extractor.get_lemma_candidate("hogs", "NN") == "hog"), function main, file LemmaExtractor.cc, line 666.
Abort trap: 6
```

```
> ./TEST_TrellisColumn
libc++abi.dylib: terminating with uncaught exception of type std::out_of_range: vector
Abort trap: 6
```
