### PR TITLE
Flush output stream in omorfi2finnpos

### DIFF
--- a/bin/finnpos-restore-lemma.py
+++ b/bin/finnpos-restore-lemma.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 
-from sys import stdin
+from sys import stdin, stdout
 
 def part_count(lemma):
     return lemma.count('#')
@@ -24,6 +24,7 @@ for line in stdin:
 
     if line == '':
         print('')
+        stdout.flush()
     else:
         wf, feats, lemma, label, ann = line.split('\t')
 

--- a/bin/omorfi2finnpos.py
+++ b/bin/omorfi2finnpos.py
@@ -1,4 +1,4 @@
-from sys import stdin, argv, stderr
+from sys import stdin, argv, stderr, stdout
 from re import findall
 
 def get_lemma(string, convert_type):
@@ -80,6 +80,7 @@ def convert(pname, ifile, convert_type):
             wf, analyses = '', []
             
         elif line == '':
+            stdout.flush()
             continue
 
         elif (convert_type == 'ftb' and 


### PR DESCRIPTION
Currently when using the ftb-label, results won't print straight after a sentence is finished due to the 4k pipe buffer. I'm not sure if this is the intended behaviour, but I'm trying to use this script interactively and the buffering gets in the way. This PR flushes the output stream in omorfi2finnpos which makes ftb-label print results immediately after a sentence is terminated by a newline.
